### PR TITLE
fix deserialization of schema'd mummy messages

### DIFF
--- a/datahog/const/util.py
+++ b/datahog/const/util.py
@@ -176,10 +176,9 @@ def storage_unwrap(ctx, value):
 
     if st == storage.SERIAL:
         schema = ctx_schema(ctx)
+        value = mummy.loads(value)
         if schema:
-            value = schema.untransform(mummy.loads(value))
-        else:
-            value = mummy.loads(value)
+            value = schema.loads(value).message
 
     return value
 


### PR DESCRIPTION
looks like there was an error in datahog's consumption of mummy? i'm not 100% clear on why it was wrong, but i discovered something that worked by poking at mummy in the interpreter. 

if you want some more details on the error, here's [a repro script + output](https://gist.github.com/cameron/11756d03053f72a334b6)
